### PR TITLE
Add Enter, Menu, and Join Pages with Updated Initial Routing Flow

### DIFF
--- a/src/app/enter/page.tsx
+++ b/src/app/enter/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useClient } from "@/app/context/ClientContext";
+import axios from "axios";
+
+export default function EnterPage() {
+  const { setClientName } = useClient();
+  const router = useRouter();
+  const [name, setName] = useState("");
+
+  const handleSubmit = async () => {
+    if (!name.trim()) return;
+
+    const formData = new FormData();
+    formData.append("client_name", name);
+
+    try {
+      const res = await axios.post("http://localhost:3001/api/set_name", formData, {
+        withCredentials: true,
+      });
+
+      //store the name in context and navigate to /menu
+      if (res.data.Result === "Success") {
+        setClientName(name);     // update name globally
+        router.push("/menu");
+      } else {
+        alert("Failed to set name. Please try again.");
+      }
+    } catch (err) {
+      console.error("Error setting name:", err);
+      alert("Could not connect to server.");
+    }
+  };
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md text-center">
+        <h1 className="text-2xl font-bold mb-4">Welcome to the Real-Time Polling App</h1>
+        <p className="flex flex-col items-center text-gray-600 mb-4">Enter your name to begin</p>
+        <div className="flex flex-col items-center">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your name"
+            className="border w-full p-2 mb-4"
+          />
+
+          {/* Submit button to trigger name registration */}
+          <button
+            onClick={handleSubmit}
+            className="block w-full bg-blue-500 text-white px-4 py-2 rounded"
+          >
+            Enter
+          </button>
+        </div>
+      </div>
+    </main>
+
+  );
+}

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function JoinPollPage() {
+  const [code, setCode] = useState("");
+  const router = useRouter();
+
+  const handleJoin = () => {
+    const trimmedCode = code.trim();
+
+    // Check for valid 4-digit (or 4-char) code
+    if (trimmedCode.length != 4) {
+      alert("Please enter a valid poll code.");
+      return;
+    }
+
+    // Redirect to the poll page
+    router.push(`/poll/${trimmedCode}`);
+  };
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md text-center">
+        <h1 className="flex flex-col items-center text-2xl font-bold mb-4">Join a Poll</h1>
+        <p className="flex flex-col items-center text-gray-600 mb-4">Enter your 4-digit poll code</p>
+        <div className="flex flex-col items-center gap-4 w-full">
+          <input
+            type="text"
+            maxLength={10}
+            placeholder="e.g. 1234"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            className="border border-gray-300 rounded w-full p-2 text-center text-lg"
+          />
+
+          <button
+            onClick={handleJoin}
+            className="bg-blue-500 text-white px-4 py-2 rounded w-full hover:bg-blue-600 transition"
+          >
+            Join Poll
+          </button>
+
+          <button
+            onClick={() => router.push("/menu")}
+            className="text-gray-500 hover:underline text-sm"
+          >
+            Back to Menu
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useClient } from "@/app/context/ClientContext";
+
+export default function MenuPage() {
+  const router = useRouter();
+  const { clientName } = useClient();
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-gray-100 p-4">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md text-center">
+        <h1 className="text-2xl font-bold mb-4">Welcome <span className="font-semibold">{clientName || "Guest"}</span>!</h1>
+        <p className="flex flex-col items-center text-gray-600 mb-4">Select an action:</p>
+
+        <div className="flex flex-col items-center gap-4 w-full">
+          <button
+            onClick={() => router.push("/create")}
+            className="bg-green-500 text-white w-full py-3 rounded hover:bg-green-600 transition"
+          >
+            Create a Poll
+          </button>
+
+          <button
+            onClick={() => router.push("/join")}
+            className="bg-blue-500 text-white w-full py-3 rounded hover:bg-blue-600 transition"
+          >
+            Join a Poll
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,96 +3,105 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
-import { useClient } from "./context/ClientContext"; // Adjust path as needed
+//import { useClient } from "./context/ClientContext"; // Adjust path as needed
 
-type Poll = {
-  id: string;
-  title: string;
-};
-
-export default function HomePage() {
+export default function RedirectToEnter() {
   const router = useRouter();
-  const { clientName, setShowPopup, socket } = useClient();
-  const [polls, setPolls] = useState<Poll[]>([]);
-  const [loading, setLoading] = useState(true);
 
-  // Function to fetch polls
-  const fetchPolls = () => {
-    axios
-      .get("http://localhost:3001/api/polls", { withCredentials: true })
-      .then((res) => {
-        setPolls(res.data.polls);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Error fetching polls:", err);
-        setLoading(false);
-      });
-  };
-
-  // Listen for the refresh event from the socket.
   useEffect(() => {
-    if (socket) {
-      socket.on("refreshPolls", () => {
-        console.log("Refresh polls event received from socket");
-        fetchPolls();
-      });
-    }
-    return () => {
-      if (socket) {
-        socket.off("refreshPolls");
-      }
-    };
-  }, [socket]);
-
-
-  // Initial fetch on component mount.
-  useEffect(() => {
-    fetchPolls();
+    router.push("/enter"); // Immediately redirect to the Enter page
   }, []);
 
-  if (loading) {
-    return <div>Loading...</div>;
-  }
-
-  return (
-    <main className="min-h-screen p-4">
-      <h1 className="text-3xl font-bold mb-4">Join a Poll</h1>
-      <p className="mb-4">Hello, {clientName || "Guest"}!</p>
-      <button
-        onClick={() => setShowPopup(true)}
-        className="bg-blue-500 text-white px-4 py-2 rounded mb-4"
-      >
-        Change Name
-      </button>
-
-      <div className="mt-6">
-        <h2 className="text-xl mb-2">Active Polls</h2>
-        {polls.length === 0 ? (
-          <p>No active polls available.</p>
-        ) : (
-          <ul className="list-disc pl-5">
-            {polls.map((poll) => (
-              <li key={poll.id} className="flex items-center mb-2">
-                <span className="mr-2">{poll.title}</span>
-                <button
-                  onClick={() => router.push(`/poll/${poll.id}`)}
-                  className="underline text-blue-500"
-                >
-                  Join Poll
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <button
-        onClick={() => router.push("/create")}
-        className="mt-4 bg-green-500 text-white px-4 py-2 rounded"
-      >
-        Create New Poll
-      </button>
-    </main>
-  );
+  return null; // Nothing gets rendered on this page
 }
+// type Poll = {
+//   id: string;
+//   title: string;
+// };
+//
+// export default function HomePage() {
+//   const router = useRouter();
+//   const { clientName, setShowPopup, socket } = useClient();
+//   const [polls, setPolls] = useState<Poll[]>([]);
+//   const [loading, setLoading] = useState(true);
+//
+//   // Function to fetch polls
+//   const fetchPolls = () => {
+//     axios
+//       .get("http://localhost:3001/api/polls", { withCredentials: true })
+//       .then((res) => {
+//         setPolls(res.data.polls);
+//         setLoading(false);
+//       })
+//       .catch((err) => {
+//         console.error("Error fetching polls:", err);
+//         setLoading(false);
+//       });
+//   };
+//
+//   // Listen for the refresh event from the socket.
+//   useEffect(() => {
+//     if (socket) {
+//       socket.on("refreshPolls", () => {
+//         console.log("Refresh polls event received from socket");
+//         fetchPolls();
+//       });
+//     }
+//     return () => {
+//       if (socket) {
+//         socket.off("refreshPolls");
+//       }
+//     };
+//   }, [socket]);
+//
+//
+//   // Initial fetch on component mount.
+//   useEffect(() => {
+//     fetchPolls();
+//   }, []);
+//
+//   if (loading) {
+//     return <div>Loading...</div>;
+//   }
+//
+//   return (
+//     <main className="min-h-screen p-4">
+//       <h1 className="text-3xl font-bold mb-4">Join a Poll</h1>
+//       <p className="mb-4">Hello, {clientName || "Guest"}!</p>
+//       <button
+//         onClick={() => setShowPopup(true)}
+//         className="bg-blue-500 text-white px-4 py-2 rounded mb-4"
+//       >
+//         Change Name
+//       </button>
+//
+//       <div className="mt-6">
+//         <h2 className="text-xl mb-2">Active Polls</h2>
+//         {polls.length === 0 ? (
+//           <p>No active polls available.</p>
+//         ) : (
+//           <ul className="list-disc pl-5">
+//             {polls.map((poll) => (
+//               <li key={poll.id} className="flex items-center mb-2">
+//                 <span className="mr-2">{poll.title}</span>
+//                 <button
+//                   onClick={() => router.push(`/poll/${poll.id}`)}
+//                   className="underline text-blue-500"
+//                 >
+//                   Join Poll
+//                 </button>
+//               </li>
+//             ))}
+//           </ul>
+//         )}
+//       </div>
+//
+//       <button
+//         onClick={() => router.push("/create")}
+//         className="mt-4 bg-green-500 text-white px-4 py-2 rounded"
+//       >
+//         Create New Poll
+//       </button>
+//     </main>
+//   );
+// }


### PR DESCRIPTION
What’s Done:
- Landing Page: App now opens directly to the Enter page
- Enter Page: User enters their name and submits → redirected to the Menu page
- Menu Page: User can choose to: Join a poll → goes to Join page OR Create a poll → goes to Create page
- Join Page: Asks user for a 4-digit code to join a poll

What’s Still Needed:
- Poll Code Validation: Logic to check if the entered code is valid and route to the corresponding poll
- Return to Menu Button on Create Page (optional): Useful if a user accidentally selected "Create" instead of "Join" (can also be handled with a back arrow)
- Poll Code Display Page: After creating a poll, show the user their unique poll code
- Aesthetic Changes (optional)

Works on my end and should integrate cleanly into main. Let me know if anything looks off!